### PR TITLE
[C] Applies project-config when building container from image

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -25,5 +25,7 @@ if [ -f composer.json ]; then
     done
 fi
 
+./craft project-config/apply
+
 # https://docs.docker.com/engine/reference/builder/#exec-form-entrypoint-example
 exec "$@"


### PR DESCRIPTION
This commit I think correctly implements the missing project-config command.